### PR TITLE
change SLOAD to MLOAD to save gas

### DIFF
--- a/src/lib/OrderValidator.sol
+++ b/src/lib/OrderValidator.sol
@@ -198,7 +198,7 @@ contract OrderValidator is Executor, ZoneInteraction {
         orderHash = _assertConsiderationLengthAndGetOrderHash(orderParameters);
 
         // Retrieve the order status using the derived order hash.
-        OrderStatus memory orderStatus = _orderStatus[orderHash];
+        OrderStatus storage orderStatus = _orderStatus[orderHash];
 
         // Ensure order is fillable and is not cancelled.
         if (

--- a/src/lib/OrderValidator.sol
+++ b/src/lib/OrderValidator.sol
@@ -198,7 +198,7 @@ contract OrderValidator is Executor, ZoneInteraction {
         orderHash = _assertConsiderationLengthAndGetOrderHash(orderParameters);
 
         // Retrieve the order status using the derived order hash.
-        OrderStatus storage orderStatus = _orderStatus[orderHash];
+        OrderStatus memory orderStatus = _orderStatus[orderHash];
 
         // Ensure order is fillable and is not cancelled.
         if (

--- a/src/lib/Verifiers.sol
+++ b/src/lib/Verifiers.sol
@@ -227,7 +227,7 @@ contract Verifiers is Assertions, SignatureVerification {
      */
     function _verifyOrderStatus(
         bytes32 orderHash,
-        OrderStatus storage orderStatus,
+        OrderStatus memory orderStatus,
         bool onlyAllowUnused,
         bool revertOnInvalid
     ) internal view returns (bool valid) {


### PR DESCRIPTION
Reading a storage variable costs more gas than reading a memory variable. The value of ```orderStatus``` in function ```_validateOrderAndUpdateStatus``` and ```_verifyOrderStatus``` is not changed, thus it could save much gas to change the data location from storage to memory.